### PR TITLE
Update to latest Odin version, LLVM17 and enable MacOS again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
+    # NOTE: odin macos and ubuntu releases are zipped twice, so this is bit of a hack.
+    # The examples folder also conflicts with the sokol examples, so we just remove it.
     steps:
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
@@ -21,9 +23,8 @@ jobs:
           echo "/usr/lib/llvm-17/bin" >> $GITHUB_PATH
           curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-ubuntu-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
-          # HACK: odin releases are zipped twice
           unzip dist.zip
-          rm -r ./dist/examples # Sokol already has an examples folder
+          rm -r ./dist/examples
           mv ./dist/* ./
           chmod a+x ./odin
           ./build_clibs_linux.sh
@@ -33,6 +34,9 @@ jobs:
           brew install llvm@17
           curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-macos-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
+          unzip dist.zip
+          rm -r ./dist/examples
+          mv ./dist/* ./
           chmod a+x ./odin
           ./build_clibs_macos.sh
       - if: runner.os == 'Windows'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
           echo "/usr/lib/llvm-17/bin" >> $GITHUB_PATH
           curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-ubuntu-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
+          # HACK: odin releases are zipped twice
+          unzip dist.zip
+          mv ./dist/* ./
           chmod a+x ./odin
           ./build_clibs_linux.sh
       - if: runner.os == 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        # NOTE: disable macOS because llvm@11 is no longer supported in Homebrew
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +30,7 @@ jobs:
       - if: runner.os == 'macOS'
         name: prepare-macos
         run: |
-          brew install llvm@11
+          brew install llvm@17
           curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-macos-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev llvm-11
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-07/odin-ubuntu-amd64-dev-2023-07.zip --output odin.zip
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-macos-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_linux.sh
@@ -26,7 +26,7 @@ jobs:
         name: prepare-macos
         run: |
           brew install llvm@11
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-07/odin-macos-amd64-dev-2023-07.zip --output odin.zip
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-ubuntu-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_macos.sh
@@ -34,7 +34,7 @@ jobs:
         name: prepare-windows
         shell: cmd
         run: |
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-07/odin-windows-amd64-dev-2023-07.zip --output odin.zip
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-windows-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
           build_clibs_windows.cmd
       - name: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,11 @@ jobs:
         name: prepare-linux
         run: |
           sudo apt-get update
-          sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev llvm-11
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-macos-amd64-dev-2024-04.zip --output odin.zip
+          sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          echo "/usr/lib/llvm-17/bin" >> $GITHUB_PATH
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-ubuntu-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_linux.sh
@@ -26,7 +29,7 @@ jobs:
         name: prepare-macos
         run: |
           brew install llvm@11
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-ubuntu-amd64-dev-2024-04.zip --output odin.zip
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2024-04/odin-macos-amd64-dev-2024-04.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_macos.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     # NOTE: odin macos and ubuntu releases are zipped twice, so this is bit of a hack.
     # The examples folder also conflicts with the sokol examples, so we just remove it.
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
       - if: runner.os == 'Linux'
         name: prepare-linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
           unzip odin.zip
           # HACK: odin releases are zipped twice
           unzip dist.zip
+          rm -r ./dist/examples # Sokol already has an examples folder
           mv ./dist/* ./
           chmod a+x ./odin
           ./build_clibs_linux.sh


### PR DESCRIPTION
This PR upgrades to the latest odin build, and makes use of LLVM 17. On windows it comes by default, mac has `llvm@17` in brew and on linux it's installed with a script.

Note: the linux and macos odin releases are zipped twice for some reason, so the additional unzipping is a temporary hack.

MacOS was previously disabled because of deprecated `llvm@11` but now works again.

I also upgraded to `checkouts@v4` since `v3` triggered deprecated warnings.