### PR TITLE
Fix Allocator function argument type in helpers

### DIFF
--- a/examples/instancing/main.odin
+++ b/examples/instancing/main.odin
@@ -7,6 +7,7 @@
 package main
 
 import "base:runtime"
+import "core:c"
 import slog "../../sokol/log"
 import sg "../../sokol/gfx"
 import sapp "../../sokol/app"
@@ -123,7 +124,7 @@ frame :: proc "c" () {
     // update instance data
     sg.update_buffer(state.bind.vertex_buffers[1], {
         ptr = &state.pos,
-        size = u64(state.cur_num_particles * size_of(m.vec3)),
+        size = c.size_t(state.cur_num_particles * size_of(m.vec3)),
     })
 
     // vertex shader uniform data with model-view-projection matrix

--- a/sokol/helpers/allocator.odin
+++ b/sokol/helpers/allocator.odin
@@ -5,9 +5,10 @@ package sokol_helpers
 import sapp "../app"
 import sg "../gfx"
 import "base:runtime"
+import "core:c"
 
 Allocator :: struct {
-    alloc_fn:  proc "c" (size: u64, user_data: rawptr) -> rawptr,
+    alloc_fn:  proc "c" (size: c.size_t, user_data: rawptr) -> rawptr,
     free_fn:   proc "c" (ptr: rawptr, user_data: rawptr),
     user_data: rawptr,
 }
@@ -22,7 +23,7 @@ allocator :: proc(context_ptr: ^runtime.Context) -> Allocator {
     }
 }
 
-allocator_alloc_proc :: proc "c" (size: u64, user_data: rawptr) -> rawptr {
+allocator_alloc_proc :: proc "c" (size: c.size_t, user_data: rawptr) -> rawptr {
     context = (cast(^runtime.Context)user_data)^
     bytes, err := runtime.mem_alloc(size = int(size))
     if err != nil {


### PR DESCRIPTION
This corresponds to a change in the bindgen mappings, see floooh/sokol#1157 and floooh/sokol#1158, except this file is not automatically generated.

There are corresponding changes for the package-specific `Allocator`s as a result of bindgen changes in floooh/sokol#1158, but those changes are not included here.