### PR TITLE
build_clibs_linux.sh: Build shared libraries

### DIFF
--- a/sokol/build_clibs_linux.sh
+++ b/sokol/build_clibs_linux.sh
@@ -5,8 +5,11 @@ build_lib_x64_release() {
     dst=$2
     backend=$3
     echo $dst
+    # static
     cc -pthread -c -O2 -DNDEBUG -DIMPL -D$backend c/$src.c
     ar rcs $dst.a $src.o
+    # shared
+    cc -pthread -shared -O2 -fPIC -DNDEBUG -DIMPL -D$backend -o $dst.so c/$src.c
 }
 
 build_lib_x64_debug() {
@@ -14,8 +17,11 @@ build_lib_x64_debug() {
     dst=$2
     backend=$3
     echo $dst
+    # static
     cc -pthread -c -g -DIMPL -D$backend c/$src.c
     ar rcs $dst.a $src.o
+    # shared
+    cc -pthread -shared -g -fPIC -DIMPL -D$backend -o $dst.so c/$src.c
 }
 
 # x64 + GL + Release


### PR DESCRIPTION
This adds support for shared libraries on linux, enabling hot reloading without having to mess with the sokol app state. Hot reloading via static lib causes issues which can only be solved by persisting the internal sokol app state, which isn't available from Odin.
With a shared library, hot reloading works out of the box and makes development super fast.

`-fPIC` is required when compiling as a shared library.

Let me know if you prefer these to be a separate script (like MacOS).

Corresponding PR in the main sokol repo for the Odin generator:
https://github.com/floooh/sokol/pull/1172