### PR TITLE
Use .a instead of .lib when generating WASM libs

### DIFF
--- a/sokol/build_clibs_wasm.bat
+++ b/sokol/build_clibs_wasm.bat
@@ -4,16 +4,16 @@ set sources=log app gfx glue time audio debugtext shape gl
 
 REM Debug
 for %%s in (%sources%) do (
-	echo %%s\sokol_%%s_wasm_gl_debug.lib
+    echo %%s\sokol_%%s_wasm_gl_debug.a
     call emcc -c -g -DIMPL -DSOKOL_GLES3 c\sokol_%%s.c
-    call emar rcs %%s\sokol_%%s_wasm_gl_debug.lib sokol_%%s.o
+    call emar rcs %%s\sokol_%%s_wasm_gl_debug.a sokol_%%s.o
     del sokol_%%s.o
 )
 
 REM Release
 for %%s in (%sources%) do (
-	echo %%s\sokol_%%s_wasm_gl_release.lib
+    echo %%s\sokol_%%s_wasm_gl_release.a
     call emcc -c -O2 -DNDEBUG -DIMPL -DSOKOL_GLES3 c\sokol_%%s.c
-    call emar rcs %%s\sokol_%%s_wasm_gl_release.lib sokol_%%s.o
+    call emar rcs %%s\sokol_%%s_wasm_gl_release.a sokol_%%s.o
     del sokol_%%s.o
 )

--- a/sokol/build_clibs_wasm.sh
+++ b/sokol/build_clibs_wasm.sh
@@ -4,16 +4,16 @@ declare -a libs=("log" "gfx" "app" "glue" "time" "audio" "debugtext" "shape" "gl
 
 for l in "${libs[@]}"
 do
-    echo "${l}/sokol_${l}_wasm_gl_debug.lib"
+    echo "${l}/sokol_${l}_wasm_gl_debug.a"
     emcc -c -g -DIMPL -DSOKOL_GLES3 c/sokol_$l.c
-    emar rcs $l/sokol_${l}_wasm_gl_debug.lib sokol_$l.o
+    emar rcs $l/sokol_${l}_wasm_gl_debug.a sokol_$l.o
     rm sokol_$l.o
 done
 
 for l in "${libs[@]}"
 do
-    echo "${l}/sokol_${l}_wasm_gl_release.lib"
+    echo "${l}/sokol_${l}_wasm_gl_release.a"
     emcc -c -O2 -DNDEBUG -DIMPL -DSOKOL_GLES3 c/sokol_$l.c
-    emar rcs $l/sokol_${l}_wasm_gl_release.lib sokol_$l.o
+    emar rcs $l/sokol_${l}_wasm_gl_release.a sokol_$l.o
     rm sokol_$l.o
 done


### PR DESCRIPTION
Use `.a` instead of `.lib` on WASM libs as it should be. My bad!