### PR TITLE
shebang for linux wasm clibs shell script

### DIFF
--- a/sokol/build_clibs_wasm.sh
+++ b/sokol/build_clibs_wasm.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 
 declare -a libs=("log" "gfx" "app" "glue" "time" "audio" "debugtext" "shape" "gl")


### PR DESCRIPTION
the declare line fails in non-bash shells, added shebang to be explicit