### PR TITLE
Remove unused imports in `helper`

### DIFF
--- a/sokol/helpers/allocator.odin
+++ b/sokol/helpers/allocator.odin
@@ -2,8 +2,6 @@ package sokol_helpers
 
 // Use native odin allocators in sokol allocator interface
 
-import sapp "../app"
-import sg "../gfx"
 import "base:runtime"
 import "core:c"
 

--- a/sokol/helpers/logger.odin
+++ b/sokol/helpers/logger.odin
@@ -2,8 +2,6 @@ package sokol_helpers
 
 // Pass sokol logs into native odin logging system
 
-import sapp "../app"
-import sg "../gfx"
 import "base:runtime"
 import "core:log"
 


### PR DESCRIPTION
These imports are unused in these files, and trigger errors when compiling with `-vet` flags